### PR TITLE
fix(pages): consolidate titles into metadata and drop redundant useEffect

### DIFF
--- a/src/app/chat/metadata.js
+++ b/src/app/chat/metadata.js
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: 'Chat with Pradumna',
+  title: 'Pradumna Saraf | Schedule a Meeting',
   description:
     'Schedule a meeting with me for consulting, speaking, or just to chat.',
   keywords:

--- a/src/app/chat/page.js
+++ b/src/app/chat/page.js
@@ -1,14 +1,10 @@
 'use client';
 import './style.css';
 import { useEffect } from 'react';
-import Head from 'next/head';
 import Link from 'next/link';
 
 const ChatPage = () => {
   useEffect(() => {
-    document.title = 'Pradumna Saraf | Schedule a Meeting';
-    // Note: Google Tag Manager is loaded globally in layout.js, so we no longer inject it here.
-
     // Cal inline embed code
     const calScript = document.createElement('script');
     calScript.type = 'text/javascript';
@@ -59,16 +55,6 @@ const ChatPage = () => {
 
   return (
     <>
-      <Head>
-        <link
-          rel="icon"
-          href="https://user-images.githubusercontent.com/51878265/194138074-7a341083-e80e-49d9-8e58-02882b26d3d9.png"
-        />
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Schedule a Meeting</title>
-      </Head>
-
       <div className="chat-page">
         <div className="page-topbar" role="banner">
           <div className="page-topbar-inner">

--- a/src/app/cv/metadata.js
+++ b/src/app/cv/metadata.js
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: "Pradumna's CV",
+  title: 'Pradumna Saraf | CV',
   description:
     'My CV and work experience in open source, content creation, and community building.',
   keywords:

--- a/src/app/cv/page.js
+++ b/src/app/cv/page.js
@@ -1,6 +1,4 @@
-'use client';
 import './style.css';
-import { useEffect } from 'react';
 import Link from 'next/link';
 import {
   FaGithub,
@@ -12,20 +10,6 @@ import {
 } from 'react-icons/fa';
 
 const CVPage = () => {
-  useEffect(() => {
-    document.title = 'Pradumna Saraf | CV';
-
-    const linkElement = document.createElement('link');
-    linkElement.rel = 'stylesheet';
-    linkElement.href =
-      'https://fonts.googleapis.com/css2?family=League+Spartan:wght@300;400;500&display=swap';
-    document.head.appendChild(linkElement);
-
-    return () => {
-      document.head.removeChild(linkElement);
-    };
-  }, []);
-
   return (
     <>
       <div className="page-topbar" role="banner">
@@ -274,7 +258,6 @@ const CVPage = () => {
               </div>
               <ul>
                 <li>
-                  {' '}
                   I was recognized as a Microsoft Most Valuable Professional
                   (MVP) in the Developer Technologies category (Technology Area:
                   DevOps) for my contributions to the developer community from

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,13 +1,11 @@
-'use client';
 import './not-found.css';
 import Link from 'next/link';
-import { useEffect } from 'react';
+
+export const metadata = {
+  title: '404 - Page Not Found | Pradumna Saraf',
+};
 
 export default function NotFound() {
-  useEffect(() => {
-    document.title = '404 - Page Not Found | Pradumna Saraf';
-  }, []);
-
   return (
     <div className="not-found-container">
       <div className="not-found-content">

--- a/src/app/photography/metadata.js
+++ b/src/app/photography/metadata.js
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: "Pradumna's Photography",
+  title: 'Pradumna Saraf | Photography',
   description:
     'My mobile photography shots - a mix of personal and professional shots.',
   keywords:

--- a/src/app/photography/page.js
+++ b/src/app/photography/page.js
@@ -644,8 +644,6 @@ export default function Home() {
   };
 
   useEffect(() => {
-    document.title = 'Pradumna Saraf | Photography'; // Set the document title
-
     // Show welcome popup when page loads
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setShowWelcomePopup(true);

--- a/src/app/timeline/metadata.js
+++ b/src/app/timeline/metadata.js
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: "Pradumna's Professional Timeline",
+  title: 'Pradumna Saraf | Timeline',
   description: 'My professional journey - from early career to now.',
   keywords:
     'Pradumna Saraf Timeline, Professional Journey, Career Timeline, Developer Advocate Journey, Docker Captain Journey, Career Milestones',

--- a/src/app/timeline/page.js
+++ b/src/app/timeline/page.js
@@ -1,28 +1,8 @@
-'use client';
 import './style.css';
-import { useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 
-// Remove export metadata since this is a client component and won't work
-// Metadata is already defined in src/app/timeline/metadata.js
-
 const TimelinePage = () => {
-  useEffect(() => {
-    document.title = 'Pradumna Saraf | Timeline'; // Set the document title
-
-    // Add League Spartan font
-    const linkElement = document.createElement('link');
-    linkElement.rel = 'stylesheet';
-    linkElement.href =
-      'https://fonts.googleapis.com/css2?family=League+Spartan:wght@300;400;500&display=swap';
-    document.head.appendChild(linkElement);
-
-    return () => {
-      document.head.removeChild(linkElement);
-    };
-  }, []);
-
   return (
     <>
       <div className="page-topbar" role="banner">
@@ -112,7 +92,6 @@ const TimelinePage = () => {
               <h2>Microsoft MVP</h2>
               <small>November, 2025</small>
               <p>
-                {' '}
                 I was recognized as a Microsoft Most Valuable Professional (MVP)
                 in the Developer Technologies category (Technology Area: DevOps)
                 for my contributions to the developer community from writing
@@ -150,7 +129,6 @@ const TimelinePage = () => {
               <h2>Docker Captain of the Year</h2>
               <small>October, 2025</small>
               <p>
-                {' '}
                 I was honored with the Docker Captain of the Year award,
                 recognizing my contributions to the Docker community. This award
                 was presented during Docker Captains Summit 2025 in Istanbul,
@@ -188,7 +166,6 @@ const TimelinePage = () => {
               <h2>Featured in Docker Captain Interview</h2>
               <small>October, 2025</small>
               <p>
-                {' '}
                 {
                   "Featured in Docker's official blog as part of their \"From the Captain's Chair\" series. Shared my journey from learning about databases to becoming a Docker Captain, my contributions to the community, and insights on Docker's latest features."
                 }
@@ -225,7 +202,6 @@ const TimelinePage = () => {
               <h2>Joined Kestra as a QAE</h2>
               <small>September, 2025</small>
               <p>
-                {' '}
                 I joined Kestra as a Quality Assurance Engineer. I test new
                 features, run automated checks, and identify bugs to ensure
                 software quality across both open source and enterprise
@@ -263,7 +239,6 @@ const TimelinePage = () => {
               <h2>Delivered a talk at KubeCon India</h2>
               <small>August, 2025</small>
               <p>
-                {' '}
                 I delivered a talk at KubeCon India, a premier conference
                 focusing on Kubernetes and Cloud Native technologies. I spoke
                 about WebAssembly and Docker adoption and development process.
@@ -302,7 +277,6 @@ const TimelinePage = () => {
               <h2>Featured on maintaine.rs Book</h2>
               <small>July, 2025</small>
               <p>
-                {' '}
                 I was featured on maintaine.rs book, a collection of stories
                 from maintainers in open source world. I was featured for my
                 work as a maintainer and contributor to the open source
@@ -342,7 +316,6 @@ const TimelinePage = () => {
               <h2>Delivered my first talk at International Conference</h2>
               <small>June, 2025</small>
               <p>
-                {' '}
                 It was my first time attending and delivering a talk at an
                 international conference, KubeCon China in Hong Kong. I spoke
                 about WebAssembly and Docker development.
@@ -421,7 +394,6 @@ const TimelinePage = () => {
               <h2>Delivered a talk at Linux Foundation event</h2>
               <small>December, 2024</small>
               <p>
-                {' '}
                 I delivered a talk at the SOSS Community Day, India (KubeCon
                 India), hosted by the Linux Foundation/CNCF. This was the first
                 event of its kind in India. I delivered a talk on Software
@@ -464,7 +436,6 @@ const TimelinePage = () => {
               <h2>Published first blog on FreeCodeCamp</h2>
               <small>November, 2024</small>
               <p>
-                {' '}
                 Last year I get approved as a writer at FreeCodeCamp. Finally
                 get some time to write a detailed blog apart from my regular
                 writing on Dev.to. The blog was how Feature Flags can in be
@@ -507,7 +478,6 @@ const TimelinePage = () => {
               <h2>Part of Docker Official Docs team</h2>
               <small>August, 2024</small>
               <p>
-                {' '}
                 I was invited to official Docker docs team as a Docker Captain.
                 I am one of few people who are working on the official Docker
                 docs. I am helping the team to improve the docs, adding
@@ -584,7 +554,6 @@ const TimelinePage = () => {
               <h2>Invited as a Guest Speaker at NIT Patna</h2>
               <small>April, 2024</small>
               <p>
-                {' '}
                 I was invited as a guest speaker at NIT Patna to deliver a talk
                 on open source and how to effectively maintain a open source
                 project. This was the place where I delivered my first in-person
@@ -621,7 +590,6 @@ const TimelinePage = () => {
               <h2>10K Followers on Dev.to</h2>
               <small>March, 2024</small>
               <p>
-                {' '}
                 I reached 10K followers on Dev.to. I was actively writing
                 articles and helping others to get started with open source and
                 devops. At this time my total views were around 150K.
@@ -657,7 +625,6 @@ const TimelinePage = () => {
               <h2>DevOps repo crossed 2.5K Stars</h2>
               <small>February, 2024</small>
               <p>
-                {' '}
                 DevOps repository crossed 2.5K stars on GitHub. Every week
                 thousands of devs are visiting site and GitHub repo to learn
                 about DevOps and how to get started with it. The repo is used by
@@ -695,12 +662,11 @@ const TimelinePage = () => {
               <h2>100K Views on dev.to My Articles</h2>
               <small>January, 2024</small>
               <p>
-                {' '}
                 I never though people would be interested in reading my
                 articles. I reached 100K views on my articles on Dev.to. Total
                 views including other platforms are 135K. I mostly write about
                 open source devops and everything in between. And got this many
-                views just after writing 10-12 articles.{' '}
+                views just after writing 10-12 articles.
               </p>
               <span className="right-container-arrow"></span>
             </div>
@@ -733,7 +699,6 @@ const TimelinePage = () => {
               <h2>Top Author and Mod 2023 at Dev.to</h2>
               <small>December, 2023</small>
               <p>
-                {' '}
                 I was recognized as the top author and moderator at Dev.to for
                 the year 2023. I was actively writing articles and helping
                 platform to moderate the content.
@@ -769,7 +734,6 @@ const TimelinePage = () => {
               <h2>1000 GitHub Followers</h2>
               <small>September, 2023</small>
               <p>
-                {' '}
                 I reached 1000 followers on GitHub. I was actively contributing
                 to open source and helping others to get started with open
                 source.
@@ -805,7 +769,6 @@ const TimelinePage = () => {
               <h2>Delivered my first conference talk</h2>
               <small>August, 2023</small>
               <p>
-                {' '}
                 I delivered my first conference talk at Web3Conf. I talked about
                 how how to get started with open source and how to maintain a
                 open source software being a maintainer. Room was almost
@@ -842,7 +805,6 @@ const TimelinePage = () => {
               <h2>Dev Advocate at Livecycle</h2>
               <small>August, 2023</small>
               <p>
-                {' '}
                 {`I joined Livecycle as a Dev Advocate. I was deeply involved in our open source offering "Preevy" and helped developers to get started with it by creating content and delivering talks.`}
               </p>
               <span className="right-container-arrow"></span>
@@ -876,7 +838,6 @@ const TimelinePage = () => {
               <h2>10K Followers on LinkedIn</h2>
               <small>August, 2023</small>
               <p>
-                {' '}
                 I reached 10K followers on LinkedIn. Started as diversifying my
                 social media presence and people supported here as well. The
                 quality of engagement was much better than Twitter.
@@ -912,7 +873,6 @@ const TimelinePage = () => {
               <h2>Contributed to Official GitHub Open Source Guide</h2>
               <small>July, 2024</small>
               <p>
-                {' '}
                 I and other maintainers came together and worked with GitHub to
                 write a guide on how to maintain balance for open source
                 maintainers and avoid burnout.
@@ -948,7 +908,6 @@ const TimelinePage = () => {
               <h2>Delivered my first in-person talk</h2>
               <small>April, 2023</small>
               <p>
-                {' '}
                 I delivered my first in-person talk at API Days Patna at NIT
                 Patna. It was a meet-up. I talk about how using Docker and
                 Docker Compose we can develop and test our APIs locally. Also,
@@ -986,7 +945,6 @@ const TimelinePage = () => {
               <h2>Kubernetes and SIGs Org Member</h2>
               <small>December, 2022</small>
               <p>
-                {' '}
                 I became a member of Kubernetes and Kubernetes SIGs GitHub Org.
                 I was contributing to the Kubernetes Website project and helping
                 in the area of documentation, triaging issues and PRs.
@@ -1022,7 +980,6 @@ const TimelinePage = () => {
               <h2>10K Followers on Twitter</h2>
               <small>October, 2022</small>
               <p>
-                {' '}
                 I reached 10K followers on Twitter. I was regularly posting
                 about open source and learning I was doing. It was a great
                 milestone for me.
@@ -1042,7 +999,6 @@ const TimelinePage = () => {
               <h2>First Freelancing Gig</h2>
               <small>October, 2022</small>
               <p>
-                {' '}
                 I got my first freelancing gig from a open source cloud company.
                 It was a Sponsored post on my Twitter account. The gig was about
                 sharing about their open source project. This is time I realized
@@ -1079,7 +1035,6 @@ const TimelinePage = () => {
               <h2>First GitHub Sponsor</h2>
               <small>July, 2022</small>
               <p>
-                {' '}
                 I got my first GitHub sponsor. This feeling was bit overwhelming
                 because I never expected that someone would sponsor me for my
                 work. They were super generous and sponsored me.
@@ -1115,7 +1070,6 @@ const TimelinePage = () => {
               <h2>Postman Student Leader</h2>
               <small>May, 2022</small>
               <p>
-                {' '}
                 For spreading the voice and educating students about APIs and
                 Postman, I was recognized as a Postman Student Leader.
               </p>
@@ -1186,7 +1140,6 @@ const TimelinePage = () => {
               <h2>EddieHub Ambassador</h2>
               <small>April, 2022</small>
               <p>
-                {' '}
                 As I was contributing to the EddieHub community for a while and
                 passionate about open source, I was selected as an EddieHub
                 Ambassador. There were only 7 ambassadors at that time. I
@@ -1223,7 +1176,6 @@ const TimelinePage = () => {
               <h2>Crossed 1K Followers on Twitter (X)</h2>
               <small>April, 2022</small>
               <p>
-                {' '}
                 I crossed 1k followers on Twitter. I never imagined in million
                 years that people would be interested in listening to my
                 thoughts and journey. Crazy! because I never like social media
@@ -1299,7 +1251,6 @@ const TimelinePage = () => {
               <h2>Won my first Hackathon (Solo)</h2>
               <small>March, 2022</small>
               <p>
-                {' '}
                 I won my first hackathon with daily.dev, which was global. I
                 build a Discord bot that uses RSS feeds to get the bookmarked
                 articles from daily.dev and post them to the Discord server.
@@ -1336,7 +1287,6 @@ const TimelinePage = () => {
               <h2>Won Postman Hackathon</h2>
               <small>January, 2022</small>
               <p>
-                {' '}
                 Postman Hosted a hackathon called API Fest 2022. I with a team
                 of two, we build a fully functional API from scratch using
                 Node.js and MongoDB. We won the hackathon and got a chance to
@@ -1373,7 +1323,6 @@ const TimelinePage = () => {
               <h2>Delivered my first talk</h2>
               <small>January, 2022</small>
               <p>
-                {' '}
                 {`First time I got invite to deliver a talk. It was on open source and how to get started with it. It was virtually and the fact that I delivered the talk via my $100 phone because laptop mic and camera was broken and battery don't work. Check the link for the phone screenshot I posted on Twitter.`}
               </p>
               <span className="left-container-arrow"></span>
@@ -1442,7 +1391,6 @@ const TimelinePage = () => {
               <h2>Open Source Maintainer</h2>
               <small>August, 2021</small>
               <p>
-                {' '}
                 This was my first experience as a maintainer. I became a
                 maintainer at EddieHub because I was contributing to the
                 community projects and helping others on the GitHub Org as well

--- a/src/app/toolkit/metadata.js
+++ b/src/app/toolkit/metadata.js
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: "Pradumna's Toolkit",
+  title: 'Pradumna Saraf | Toolkit',
   description:
     'Tools, software, and gear I use daily for development and productivity.',
   keywords:

--- a/src/app/toolkit/page.js
+++ b/src/app/toolkit/page.js
@@ -1,23 +1,7 @@
-'use client';
 import './style.css';
-import { useEffect } from 'react';
 import Link from 'next/link';
 
 const ToolKitPage = () => {
-  useEffect(() => {
-    document.title = 'Pradumna Saraf | Toolkit';
-
-    const linkElement = document.createElement('link');
-    linkElement.rel = 'stylesheet';
-    linkElement.href =
-      'https://fonts.googleapis.com/css2?family=League+Spartan:wght@300;400;500&display=swap';
-    document.head.appendChild(linkElement);
-
-    return () => {
-      document.head.removeChild(linkElement);
-    };
-  }, []);
-
   return (
     <>
       <div className="page-topbar" role="banner">
@@ -68,7 +52,7 @@ const ToolKitPage = () => {
               </div>
               <div className="toolkit-item">
                 <h3>Mouse</h3>
-                <p>Logitech MXMaster 4</p>
+                <p>Logitech MX Master 4</p>
                 <p>Logitech M331</p>
               </div>
               <div className="toolkit-item">
@@ -83,13 +67,12 @@ const ToolKitPage = () => {
           </section>
 
           <section className="toolkit-section">
-            <h2>Workspace & Ergonomics & Accessories</h2>
+            <h2>Workspace, Ergonomics & Accessories</h2>
             <div className="toolkit-grid">
               <div className="toolkit-item">
                 <h3>Desk</h3>
                 <p>
-                  ErgoYou E3 Dual Motor (3 Stage) with Table-Top Standing
-                  Desk{' '}
+                  ErgoYou E3 Dual Motor (3 Stage) with Table-Top Standing Desk
                 </p>
               </div>
               <div className="toolkit-item">
@@ -110,7 +93,7 @@ const ToolKitPage = () => {
                 <h3>Development Tools</h3>
                 <p>
                   Docker, Lens Kubernetes IDE, Postman, TablePlus, MongoDB
-                  Compass{' '}
+                  Compass
                 </p>
               </div>
 
@@ -119,7 +102,7 @@ const ToolKitPage = () => {
                 <p>
                   Homebrew, Oh My Zsh, nvm, yarn, git, act, gh, helm, jq, kind,
                   kubectl, localtunnel, ngrok, zsh-autosuggestions, k9s,
-                  goreleaser, UV, go, terraform, tree, speedtest{' '}
+                  goreleaser, UV, go, terraform, tree, speedtest
                 </p>
               </div>
 
@@ -128,7 +111,7 @@ const ToolKitPage = () => {
                 <p>
                   Raycast, Lunar, LocalSend, Grammarly Desktop, GPG Suite,
                   PDFgear, VLC, Zoom, VNC Viewer, AnySwitch, OneMenu, Launchy,
-                  Logi Options+{' '}
+                  Logi Options+
                 </p>
               </div>
 
@@ -152,7 +135,7 @@ const ToolKitPage = () => {
 
               <div className="toolkit-item">
                 <h3>Browser</h3>
-                <p>Arc</p>
+                <p>Arc, Safari</p>
               </div>
 
               <div className="toolkit-item">


### PR DESCRIPTION
## Summary

- Move per-page `document.title` overrides into `metadata.js` so SSR title matches the tab title.
- Drop redundant Google Fonts `<link>` injection on cv/timeline/toolkit (already loaded via `next/font` in root layout).
- Remove dead `next/head` block in chat (no-op in App Router).
- cv, timeline, toolkit, not-found are now server components — only chat and photography keep `'use client'`.
- Clean up stray `{' '}` whitespace inside `<p>`/`<li>` blocks; functional separators preserved.
- Toolkit heading: `Workspace & Ergonomics & Accessories` → `Workspace, Ergonomics & Accessories`.

11 files, +17 / −121.

## Test plan

- [x] Build, lint, tests pass
- [x] Manually verified all affected routes on preview