### PR TITLE
refactor(components): extract PageTopbar component for shared back-button

### DIFF
--- a/src/app/chat/page.js
+++ b/src/app/chat/page.js
@@ -2,6 +2,7 @@
 import './style.css';
 import { useEffect } from 'react';
 import Link from 'next/link';
+import PageTopbar from '@/components/PageTopbar';
 
 const ChatPage = () => {
   useEffect(() => {
@@ -56,25 +57,7 @@ const ChatPage = () => {
   return (
     <>
       <div className="chat-page">
-        <div className="page-topbar" role="banner">
-          <div className="page-topbar-inner">
-            <Link href="/" className="back-button">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M19 12H5M12 19l-7-7 7-7" />
-              </svg>
-            </Link>
-          </div>
-        </div>
+        <PageTopbar />
 
         {/* NAVIGATION */}
         <div className="nav">

--- a/src/app/cv/page.js
+++ b/src/app/cv/page.js
@@ -1,5 +1,5 @@
 import './style.css';
-import Link from 'next/link';
+import PageTopbar from '@/components/PageTopbar';
 import {
   FaGithub,
   FaTwitter,
@@ -12,49 +12,31 @@ import {
 const CVPage = () => {
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-
-          <a
-            href="https://www.canva.com/design/DAF_kKnj9WI/IT8NdwVQlzRK3DaMmXm18A/edit?utm_content=DAF_kKnj9WI&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="download-cv-button"
-            title="Download CV"
+      <PageTopbar>
+        <a
+          href="https://www.canva.com/design/DAF_kKnj9WI/IT8NdwVQlzRK3DaMmXm18A/edit?utm_content=DAF_kKnj9WI&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="download-cv-button"
+          title="Download CV"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <polyline points="7 10 12 15 17 10" />
-              <line x1="12" y1="15" x2="12" y2="3" />
-            </svg>
-          </a>
-        </div>
-      </div>
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        </a>
+      </PageTopbar>
 
       <div className="cv-container">
         <div className="cv-content">

--- a/src/app/photography/page.js
+++ b/src/app/photography/page.js
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Masonry from 'react-masonry-css';
 import { createPortal } from 'react-dom';
 import './style.css';
-import Link from 'next/link';
+import PageTopbar from '@/components/PageTopbar';
 
 const images = [
   {
@@ -687,25 +687,7 @@ export default function Home() {
 
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
+      <PageTopbar />
 
       <div className="min-h-screen p-4 md:p-8 mx-4 md:mx-16 photography-page-container">
         <h1 className="photography-title">Photography</h1>

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { FaCss3Alt, FaGithub, FaJava, FaStar } from 'react-icons/fa';
 import {
   SiDocker,
@@ -20,6 +19,7 @@ import {
   SiTypescript,
 } from 'react-icons/si';
 import projects from './projects.json';
+import PageTopbar from '@/components/PageTopbar';
 import './style.css';
 
 const techIconMap = {
@@ -49,25 +49,7 @@ export default function ProjectsPage() {
 
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button" aria-label="Back to home page">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
+      <PageTopbar ariaLabel="Back to home page" />
 
       <section className="projects-page">
         <div className="projects-header">

--- a/src/app/speaking/page.js
+++ b/src/app/speaking/page.js
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { FaMapMarkerAlt, FaSlideshare, FaYoutube } from 'react-icons/fa';
 import { RiOpenSourceFill } from 'react-icons/ri';
 import {
@@ -21,6 +20,7 @@ import {
   SiWebassembly,
 } from 'react-icons/si';
 import speakingData from './speaking.json';
+import PageTopbar from '@/components/PageTopbar';
 import './style.css';
 
 const techIconMap = {
@@ -81,25 +81,7 @@ function inferTechnologies(item) {
 const SpeakingPage = () => {
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button" aria-label="Back to home page">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
+      <PageTopbar ariaLabel="Back to home page" />
 
       <div className="speaking-container">
         <div className="speaking-header">

--- a/src/app/timeline/page.js
+++ b/src/app/timeline/page.js
@@ -1,29 +1,12 @@
 import './style.css';
 import Link from 'next/link';
 import Image from 'next/image';
+import PageTopbar from '@/components/PageTopbar';
 
 const TimelinePage = () => {
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
+      <PageTopbar />
 
       <div className="min-h-screen">
         <h1 className="timeline-title">Timeline</h1>
@@ -662,7 +645,7 @@ const TimelinePage = () => {
               <h2>100K Views on dev.to My Articles</h2>
               <small>January, 2024</small>
               <p>
-                I never though people would be interested in reading my
+                I never thought people would be interested in reading my
                 articles. I reached 100K views on my articles on Dev.to. Total
                 views including other platforms are 135K. I mostly write about
                 open source devops and everything in between. And got this many

--- a/src/app/toolkit/page.js
+++ b/src/app/toolkit/page.js
@@ -1,28 +1,10 @@
 import './style.css';
-import Link from 'next/link';
+import PageTopbar from '@/components/PageTopbar';
 
 const ToolKitPage = () => {
   return (
     <>
-      <div className="page-topbar" role="banner">
-        <div className="page-topbar-inner">
-          <Link href="/" className="back-button">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
+      <PageTopbar />
 
       <div className="min-h-screen p-4 md:p-8">
         <h1 className="toolkit-title">Tools & Gear I Use</h1>

--- a/src/components/PageTopbar.js
+++ b/src/components/PageTopbar.js
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+export default function PageTopbar({ href = '/', ariaLabel, children }) {
+  return (
+    <div className="page-topbar" role="banner">
+      <div className="page-topbar-inner">
+        <Link href={href} className="back-button" aria-label={ariaLabel}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New `<PageTopbar />` component in `src/components/` replaces the duplicated `page-topbar` + back-button + inline back-arrow SVG across 7 pages (chat, cv, photography, projects, speaking, timeline, toolkit).
- Accepts optional `href`, `ariaLabel`, and `children` — cv slots its download-CV link as a child.
- Drive-by typo fix in timeline: "I never though" → "I never thought".

Stacked on top of #74. Net -98 lines across 8 files.

## Test plan

- [x] `npx next build` succeeds, all 73 static pages prerendered
- [x] `npx eslint . --max-warnings 0` passes
- [x] `node --test` passes (12/12)
- [ ] Manually verify back-button works on each of the 7 routes in the Vercel preview