### PR TITLE
refactor(components): unify sitemap topbar and share BackArrowIcon

### DIFF
--- a/src/app/sitemap/page.js
+++ b/src/app/sitemap/page.js
@@ -1,4 +1,3 @@
-'use client';
 import Link from 'next/link';
 import {
   FaHome,
@@ -15,6 +14,7 @@ import {
   FaBlog,
 } from 'react-icons/fa';
 import { sitemapPages, externalLinks } from './data.js';
+import PageTopbar from '@/components/PageTopbar';
 import './style.css';
 
 const SitemapPage = () => {
@@ -44,25 +44,10 @@ const SitemapPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <PageTopbar />
       {/* Header */}
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-4xl mx-auto px-4 py-6">
-          <Link href="/" className="back-button mb-4">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M19 12H5M12 19l-7-7 7-7" />
-            </svg>
-          </Link>
-
           <div className="flex items-center gap-3 mb-2">
             <FaSitemap className="text-2xl text-gray-700" />
             <h1 className="text-3xl font-bold text-gray-900">Site Map</h1>

--- a/src/components/BackArrowIcon.js
+++ b/src/components/BackArrowIcon.js
@@ -1,0 +1,17 @@
+export default function BackArrowIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M19 12H5M12 19l-7-7 7-7" />
+    </svg>
+  );
+}

--- a/src/components/BlogBackButton.js
+++ b/src/components/BlogBackButton.js
@@ -1,6 +1,5 @@
-'use client';
-
 import Link from 'next/link';
+import BackArrowIcon from './BackArrowIcon';
 
 export default function BlogBackButton() {
   return (
@@ -9,19 +8,7 @@ export default function BlogBackButton() {
       className="blog-post-back-button"
       aria-label="Back to Blog"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M19 12H5M12 19l-7-7 7-7" />
-      </svg>
+      <BackArrowIcon />
     </Link>
   );
 }

--- a/src/components/PageTopbar.js
+++ b/src/components/PageTopbar.js
@@ -1,23 +1,12 @@
 import Link from 'next/link';
+import BackArrowIcon from './BackArrowIcon';
 
 export default function PageTopbar({ href = '/', ariaLabel, children }) {
   return (
     <div className="page-topbar" role="banner">
       <div className="page-topbar-inner">
         <Link href={href} className="back-button" aria-label={ariaLabel}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
+          <BackArrowIcon />
         </Link>
         {children}
       </div>


### PR DESCRIPTION
## Summary

- **`/sitemap`** was declared `'use client'` despite using zero client APIs — dropped the directive so it ships as a server component, matching the other pages.
- **`/sitemap`** was hand-rolling its own back-button. Mount `<PageTopbar />` above the page's custom header so the back-button is consistent with every other page.
- **Shared icon**: the back-arrow SVG was duplicated between `PageTopbar.js` and `BlogBackButton.js`. Extract into `<BackArrowIcon />` and import from both. `BlogBackButton` no longer needs `'use client'` either.

Stacked on #76.

## Test plan

- [x] `npx next build` succeeds, all 73 pages still prerender
- [x] `npx eslint . --max-warnings 0` passes
- [ ] Visit `/sitemap` on the Vercel preview — back button present at the top, custom header still renders normally below
- [ ] Visit any `/blog/[slug]` post — blog back button still works and looks the same