### PR TITLE
fix(blog): remove color/bg transitions that caused theme-toggle blink

### DIFF
--- a/src/app/blog/style.css
+++ b/src/app/blog/style.css
@@ -110,7 +110,9 @@
   background-color: #fff;
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
   z-index: 1000;
   text-decoration: none;
 }
@@ -124,7 +126,6 @@
   width: 24px;
   height: 24px;
   color: #333;
-  transition: color 0.3s ease;
 }
 
 .blog-post-back-button:hover svg {
@@ -143,7 +144,9 @@
   background-color: #fff;
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
   z-index: 1000;
   text-decoration: none;
 }
@@ -157,7 +160,6 @@
   width: 24px;
   height: 24px;
   color: #333;
-  transition: color 0.3s ease;
 }
 
 .blog-listing-back-button:hover svg {
@@ -2271,9 +2273,7 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition:
     transform 0.3s ease,
-    box-shadow 0.3s ease,
-    background-color 0.2s ease,
-    color 0.2s ease;
+    box-shadow 0.3s ease;
   padding: 0;
   color: #333;
 }
@@ -2297,17 +2297,11 @@
    Dark mode — strictly scoped to html[data-blog-theme='dark'] .blog-theme-root.
    Body/html are never touched, so the theme cannot leak past the blog routes.
    ========================================================================= */
-.blog-theme-root {
-  --blog-transition:
-    background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
 html[data-blog-theme='dark'] .blog-theme-root .blog-container,
 html[data-blog-theme='dark'] .blog-theme-root .blog-post-container,
 html[data-blog-theme='dark'] .blog-theme-root .blog-topbar {
   background: #0f1115;
   color: #e6e8eb;
-  transition: var(--blog-transition);
 }
 
 html[data-blog-theme='dark'] .blog-theme-root {

--- a/src/components/BlogSearch.css
+++ b/src/components/BlogSearch.css
@@ -13,7 +13,9 @@
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
   z-index: 1000;
   text-decoration: none;
   padding: 0;
@@ -47,7 +49,6 @@
   width: 24px;
   height: 24px;
   color: #333;
-  transition: color 0.3s ease;
 }
 
 /* Ensure consistent sizing even with Safari/prod CSS ordering quirks */


### PR DESCRIPTION
## Summary

When toggling between light and dark on any `/blog` page, the topbar buttons briefly appeared to "vanish." Reproduced with `agent-browser` — at ~100ms after click the icons disappeared because their background AND stroke colors were both animating through grey at the same time. Grey icon on grey button = invisible.

Same cause on the page containers (`.blog-container`, `.blog-post-container`, `.blog-topbar`): they had a transition on `background-color / color / border-color`, but the surrounding `.blog-theme-root` did not — so the inner elements faded gradually while everything else flipped instantly, making the topbar visibly lag.

## Fix

Drop the bg/color/border-color transitions on:

- `.blog-post-back-button` and its `svg`
- `.blog-listing-back-button` and its `svg`
- `.blog-search-button` / `.blog-search-close-button` and their `svg`
- `.blog-theme-toggle-button`
- The dark-mode container rule (removed the `--blog-transition` variable too — no other selector used it)

Kept `transform` and `box-shadow` transitions for the existing hover animations. Theme flip is now instant across all themed elements.

## Test plan

- [x] Reproduced before fix with `agent-browser` screenshots
- [x] Verified after fix — mid-toggle frame is clean in both directions
- [x] Build + lint pass
- [ ] Spot-check on Vercel preview: toggle theme on `/blog` index and on a `/blog/[slug]` post; hover-states still animate