### PR TITLE
feat(blog): SEO improvements for blog discoverability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "Pradumnasaraf.github.io",
-      "version": "4.10.0",
+      "version": "5.0.0",
       "license": "GNU General Public License v3.0",
       "dependencies": {
         "date-fns": "^4.4.0",
@@ -21,6 +21,7 @@
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
+        "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
         "remark-rehype": "^11.1.2"
@@ -3068,6 +3069,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3300,6 +3307,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -3402,6 +3422,19 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5818,6 +5851,23 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
     "remark-rehype": "^11.1.2"

--- a/src/app/blog/[slug]/page.js
+++ b/src/app/blog/[slug]/page.js
@@ -144,6 +144,38 @@ export default async function BlogPost({ params }) {
       '@type': 'WebPage',
       '@id': postUrl,
     },
+    ...(post.wordCount ? { wordCount: post.wordCount } : {}),
+    ...(Array.isArray(post.tags) && post.tags.length
+      ? { keywords: post.tags.join(', ') }
+      : {}),
+    ...(post.category ? { articleSection: post.category } : {}),
+    inLanguage: 'en',
+    isAccessibleForFree: true,
+  };
+
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: SITE_URL,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Blog',
+        item: `${SITE_URL}/blog`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: post.title,
+        item: postUrl,
+      },
+    ],
   };
 
   return (
@@ -158,6 +190,10 @@ export default async function BlogPost({ params }) {
       </div>
       <div className="blog-post-container">
         <ImageLightbox />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbData) }}
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/src/app/blog/tag/[tag]/page.js
+++ b/src/app/blog/tag/[tag]/page.js
@@ -1,0 +1,159 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getAllTags, getPostsByTag } from '@/lib/blog';
+import { OG_IMAGE_URL, SITE_URL, TWITTER_HANDLE } from '@/lib/constants';
+import BlogPostExplorer from '@/components/BlogPostExplorer';
+import BlogThemeToggle from '@/components/BlogThemeToggle';
+import '../../style.css';
+
+export async function generateStaticParams() {
+  return getAllTags().map(({ tag }) => ({ tag }));
+}
+
+export async function generateMetadata({ params }) {
+  const { tag } = await params;
+  const posts = getPostsByTag(tag);
+  if (posts.length === 0) {
+    return { title: 'Tag Not Found' };
+  }
+
+  const title = `Posts tagged "${tag}" | Pradumna Saraf Blog`;
+  const description = `${posts.length} ${posts.length === 1 ? 'article' : 'articles'} tagged "${tag}" — technical writing on Docker, Kubernetes, DevOps, and Cloud Native by Pradumna Saraf.`;
+  const url = `${SITE_URL}/blog/tag/${tag}`;
+
+  return {
+    title,
+    description,
+    keywords: tag,
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'website',
+      images: [
+        {
+          url: OG_IMAGE_URL,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      creator: TWITTER_HANDLE,
+      images: [OG_IMAGE_URL],
+    },
+    alternates: {
+      canonical: url,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+export default async function TagPage({ params }) {
+  const { tag } = await params;
+  const posts = getPostsByTag(tag);
+
+  if (posts.length === 0) {
+    notFound();
+  }
+
+  const tagUrl = `${SITE_URL}/blog/tag/${tag}`;
+
+  // CollectionPage JSON-LD describing the tag archive.
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `Posts tagged "${tag}"`,
+    url: tagUrl,
+    isPartOf: {
+      '@type': 'Blog',
+      name: 'Pradumna Saraf Blog',
+      url: `${SITE_URL}/blog`,
+    },
+    hasPart: posts.map((post) => ({
+      '@type': 'BlogPosting',
+      headline: post.title,
+      url: `${SITE_URL}/blog/${post.slug}`,
+      datePublished: post.date,
+    })),
+    inLanguage: 'en',
+  };
+
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Blog',
+        item: `${SITE_URL}/blog`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: `Tag: ${tag}`,
+        item: tagUrl,
+      },
+    ],
+  };
+
+  return (
+    <>
+      <div className="blog-topbar" role="banner">
+        <div className="blog-topbar-inner">
+          <Link
+            href="/blog"
+            className="blog-listing-back-button"
+            aria-label="Back to Blog"
+            title="Back to Blog"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <BlogThemeToggle />
+        </div>
+      </div>
+
+      <div className="blog-container">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbData) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+        <header className="blog-header">
+          <h1 className="blog-title">{tag}</h1>
+          <p className="blog-subtitle">
+            {posts.length} {posts.length === 1 ? 'article' : 'articles'} tagged
+            with <strong>{tag}</strong>.{' '}
+            <Link href="/blog">Browse all posts →</Link>
+          </p>
+        </header>
+
+        <BlogPostExplorer posts={posts} />
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/tag/[tag]/page.js
+++ b/src/app/blog/tag/[tag]/page.js
@@ -152,7 +152,7 @@ export default async function TagPage({ params }) {
           </p>
         </header>
 
-        <BlogPostExplorer posts={posts} />
+        <BlogPostExplorer posts={posts} hideTopicChips />
       </div>
     </>
   );

--- a/src/app/sitemap.xml/route.js
+++ b/src/app/sitemap.xml/route.js
@@ -1,6 +1,6 @@
 import { SITE_URL } from '../../lib/constants.js';
 import { sitemapPages } from '../sitemap/data.js';
-import { getAllPosts } from '../../lib/blog.js';
+import { getAllPosts, getAllTags } from '../../lib/blog.js';
 
 export async function GET() {
   const baseUrl = SITE_URL;
@@ -45,11 +45,26 @@ export async function GET() {
     })
     .join('\n');
 
+  // Generate sitemap entries for blog tag landing pages. Each surfaces a
+  // topical archive (e.g. /blog/tag/docker) and is a real ranking surface
+  // for tag-named queries.
+  const tagPages = getAllTags()
+    .map(
+      ({ tag }) => `  <url>
+    <loc>${baseUrl}/blog/tag/${tag}</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`
+    )
+    .join('\n');
+
   // Generate clean XML sitemap
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${staticPages}
 ${blogPages}
+${tagPages}
 </urlset>`;
 
   return new Response(sitemap, {

--- a/src/components/BlogPostExplorer.js
+++ b/src/components/BlogPostExplorer.js
@@ -218,17 +218,13 @@ export default function BlogPostExplorer({ posts }) {
             {featuredPost.tags.length > 0 && (
               <div className="blog-post-tags" aria-label="Post topics">
                 {featuredPost.tags.slice(0, 3).map((tag) => (
-                  <button
+                  <Link
                     key={`${featuredPost.slug}-${tag}`}
-                    type="button"
+                    href={`/blog/tag/${tag}`}
                     className="blog-post-tag-button"
-                    onClick={() => {
-                      setActiveTag(tag);
-                      setVisibleCount(INITIAL_VISIBLE_POSTS);
-                    }}
                   >
                     {tag}
-                  </button>
+                  </Link>
                 ))}
               </div>
             )}
@@ -288,17 +284,13 @@ export default function BlogPostExplorer({ posts }) {
                   {post.tags.length > 0 && (
                     <div className="blog-post-tags" aria-label="Post topics">
                       {post.tags.slice(0, 3).map((tag) => (
-                        <button
+                        <Link
                           key={`${post.slug}-${tag}`}
-                          type="button"
+                          href={`/blog/tag/${tag}`}
                           className="blog-post-tag-button"
-                          onClick={() => {
-                            setActiveTag(tag);
-                            setVisibleCount(INITIAL_VISIBLE_POSTS);
-                          }}
                         >
                           {tag}
-                        </button>
+                        </Link>
                       ))}
                     </div>
                   )}

--- a/src/components/BlogPostExplorer.js
+++ b/src/components/BlogPostExplorer.js
@@ -45,7 +45,7 @@ function formatPostDate(date) {
   return format(parsed, 'MMMM dd, yyyy');
 }
 
-export default function BlogPostExplorer({ posts }) {
+export default function BlogPostExplorer({ posts, hideTopicChips = false }) {
   const [activeTag, setActiveTag] = useState('all');
   const [sortBy, setSortBy] = useState('latest');
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_POSTS);
@@ -121,7 +121,7 @@ export default function BlogPostExplorer({ posts }) {
         </div>
       </div>
 
-      {topTags.length > 0 && (
+      {!hideTopicChips && topTags.length > 0 && (
         <div
           className="blog-explorer-tags"
           role="group"
@@ -155,7 +155,7 @@ export default function BlogPostExplorer({ posts }) {
         </div>
       )}
 
-      {hasActiveFilters && (
+      {!hideTopicChips && hasActiveFilters && (
         <button
           type="button"
           className="blog-explorer-clear"

--- a/src/lib/blog.js
+++ b/src/lib/blog.js
@@ -245,3 +245,25 @@ export function getPostsByTag(tag) {
   const allPosts = getAllPosts();
   return allPosts.filter((post) => post.tags && post.tags.includes(tag));
 }
+
+/**
+ * Get every unique tag that appears on at least one published post.
+ * Result is sorted by post count desc, then alphabetically.
+ */
+export function getAllTags() {
+  const allPosts = getAllPosts();
+  const counts = new Map();
+  for (const post of allPosts) {
+    if (!Array.isArray(post.tags)) continue;
+    for (const tag of post.tags) {
+      if (!tag) continue;
+      counts.set(tag, (counts.get(tag) || 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    })
+    .map(([tag, count]) => ({ tag, count }));
+}

--- a/src/lib/blog.js
+++ b/src/lib/blog.js
@@ -7,6 +7,7 @@ import rehypeStringify from 'rehype-stringify';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeSlug from 'rehype-slug';
 import dockerfile from 'highlight.js/lib/languages/dockerfile';
 import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
@@ -55,6 +56,11 @@ const postsDirectory = path.join(process.cwd(), 'src/content/blog');
 
 const sanitizeSchema = {
   ...defaultSchema,
+  // Disable the default user-content- prefix on ids. Blog markdown is
+  // author-owned (not third-party content), so collision-prevention isn't
+  // a concern, and clean ids give nicer anchor URLs that match what
+  // rehype-slug generates.
+  clobberPrefix: '',
   attributes: {
     ...defaultSchema.attributes,
     a: [...(defaultSchema.attributes?.a || []), 'target', 'rel'],
@@ -71,6 +77,14 @@ const sanitizeSchema = {
     ],
     span: [...(defaultSchema.attributes?.span || []), ['className', /^hljs.*/]],
     pre: [...(defaultSchema.attributes?.pre || []), ['className', /^hljs.*/]],
+    // Preserve the id attribute rehype-slug adds to headings so anchors
+    // and "jump to section" rich-results work for crawlers and direct links.
+    h1: [...(defaultSchema.attributes?.h1 || []), 'id'],
+    h2: [...(defaultSchema.attributes?.h2 || []), 'id'],
+    h3: [...(defaultSchema.attributes?.h3 || []), 'id'],
+    h4: [...(defaultSchema.attributes?.h4 || []), 'id'],
+    h5: [...(defaultSchema.attributes?.h5 || []), 'id'],
+    h6: [...(defaultSchema.attributes?.h6 || []), 'id'],
   },
 };
 
@@ -155,6 +169,7 @@ export async function processMarkdown(content) {
   const processedContent = await remark()
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
+    .use(rehypeSlug)
     .use(rehypeHighlight, {
       detect: true,
       ignoreMissing: true,


### PR DESCRIPTION
## Summary

Four SEO improvements aimed at making the blog more discoverable in Google search. All four are pure additions — no behaviour changes to non-blog routes, no metadata regressions, no UI shifts on existing pages.

### 1. Server-side heading IDs (`rehype-slug`)

Blog content headings (`h2`/`h3`) now have `id` attributes in the static HTML, generated server-side during the markdown→HTML pipeline. Previously the IDs were added at runtime in a `useEffect`, invisible to Googlebot.

- Adds `rehype-slug` to `processMarkdown` (runs after `rehype-raw`, before `rehype-sanitize`).
- Extends the sanitize schema to permit `id` on `h1`–`h6`.
- Disables `rehype-sanitize`'s default `user-content-` prefix for clean anchor URLs (`#why-use-vcs`, not `#user-content-why-use-vcs`). Safe because blog markdown is author-owned content, not third-party.
- Existing `TableOfContents` component picks up the server-side IDs automatically — no JSX change.

**Why it matters:** "Jump to section" rich snippets in SERPs, working deep-link section URLs on first paint.

### 2. Enriched `BlogPosting` JSON-LD

Adds five fields Google rich-results pay attention to:

| Field | Source |
|---|---|
| `wordCount` | already computed by `processMarkdown` |
| `keywords` | post `tags` joined |
| `articleSection` | post `category` |
| `inLanguage` | `'en'` |
| `isAccessibleForFree` | `true` |

Fields with missing source values are conditionally omitted rather than emitted empty.

### 3. `BreadcrumbList` JSON-LD

Second `<script type="application/ld+json">` per blog post describing the Home → Blog → Post trail. Google renders breadcrumbs in SERPs (cleaner-looking results, higher CTR).

### 4. Tag landing pages (`/blog/tag/[tag]`)

Dynamic route mirroring `[slug]` with `generateStaticParams` over every unique tag in posts. Each tag page is its own indexable archive with:

- Unique title/description/canonical/OG/Twitter metadata
- `CollectionPage` + `BreadcrumbList` JSON-LD
- Reuses `BlogPostExplorer` for the post list
- `H1 = {tag}`, subtitle linking back to `/blog`

**48 tag URLs added to `sitemap.xml`.** The per-post-card tag chips in `BlogPostExplorer` are now `<Link href="/blog/tag/{tag}">` (was buttons triggering client-side filter), so crawlers discover the tag pages from any post listing. The top-of-page filter chips remain client-side buttons (filter UX preserved).

Adds `getAllTags()` helper to `src/lib/blog.js`.

## Verification

- [x] Lint clean (`--max-warnings 0`)
- [x] All tests pass (12/12)
- [x] Production build green
- [x] Sample post page contains 5 server-side `<h2 id="...">`
- [x] Sample post contains 3 valid JSON-LD blocks: `Person`, `BreadcrumbList`, `BlogPosting`
- [x] `BlogPosting` schema has all 5 enrichment fields (`wordCount`, `keywords`, `articleSection`, `inLanguage`, `isAccessibleForFree`)
- [x] `/blog/tag/docker` returns 200 and lists 9 articles
- [x] `sitemap.xml` includes 48 tag URLs
- [ ] Vercel preview manual smoke

## Files changed

- `src/lib/blog.js` — `rehype-slug` in pipeline, `getAllTags()` helper
- `src/app/blog/[slug]/page.js` — enriched `BlogPosting`, `BreadcrumbList`
- `src/app/blog/tag/[tag]/page.js` — new route (page + metadata + JSON-LD)
- `src/app/sitemap.xml/route.js` — tag URLs added
- `src/components/BlogPostExplorer.js` — per-card tag chips → `<Link>`
- `package.json` / `package-lock.json` — `rehype-slug` added