### PR TITLE
feat(travel): add interactive 3D globe page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.2.0",
       "license": "GNU General Public License v3.0",
       "dependencies": {
+        "cobe": "^2.0.1",
         "date-fns": "^4.4.0",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
@@ -2022,6 +2023,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cobe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cobe/-/cobe-2.0.1.tgz",
+      "integrity": "sha512-aaa6vcIlaC8C1SF50LDH0Anybo/EAXnrxqe+bwvr4+YUtZydqjeBjTTD7ziCCkbRrRGSns3I3F6cZsf3W+L+ag==",
       "license": "MIT"
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "dependencies": {
+    "cobe": "^2.0.1",
     "date-fns": "^4.4.0",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -178,6 +178,13 @@ export default function Home() {
             <span
               className={`page-item extra-page-item ${isMobileMoreOpen ? 'active' : ''}`}
             >
+              <Link href="/travel" onClick={closeAllMenus}>
+                Travel
+              </Link>
+            </span>
+            <span
+              className={`page-item extra-page-item ${isMobileMoreOpen ? 'active' : ''}`}
+            >
               <Link
                 href="https://pradumnasaraf.substack.com"
                 rel="noopener noreferrer"
@@ -215,6 +222,9 @@ export default function Home() {
             >
               <Link href="/speaking" onClick={closeAllMenus}>
                 Speaking
+              </Link>
+              <Link href="/travel" onClick={closeAllMenus}>
+                Travel
               </Link>
               <Link
                 href="https://pradumnasaraf.substack.com"

--- a/src/app/sitemap/data.js
+++ b/src/app/sitemap/data.js
@@ -73,6 +73,16 @@ export const sitemapPages = [
     priorityLabel: 'Medium',
   },
   {
+    url: '/travel',
+    href: '/travel',
+    title: 'Travel',
+    priority: '0.6',
+    changefreq: 'monthly',
+    description: 'Places I have travelled to, shown on an interactive globe',
+    category: 'Creative',
+    priorityLabel: 'Medium',
+  },
+  {
     url: '/chat',
     href: '/chat',
     title: 'Schedule Meeting',

--- a/src/app/travel/Globe.js
+++ b/src/app/travel/Globe.js
@@ -1,0 +1,297 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import createGlobe from 'cobe';
+import travelData from './travel.json';
+
+const DEG = Math.PI / 180;
+
+const places = travelData.filter(
+  (p) => typeof p.lat === 'number' && typeof p.lng === 'number'
+);
+
+const flagOf = {};
+const nameOf = {};
+places.forEach((p) => {
+  flagOf[p.id] = p.flag || '';
+  nameOf[p.id] = p.country ? `${p.place}, ${p.country}` : p.place;
+});
+
+// Pre-compute each marker's unit-sphere vector (matches cobe's own mapping) so
+// we can tell every frame whether it faces the camera (front of the globe).
+const markers = places.map((p) => {
+  const latR = p.lat * DEG;
+  const lngR = p.lng * DEG - Math.PI;
+  const o = Math.cos(latR);
+  return {
+    id: p.id,
+    location: [p.lat, p.lng],
+    size: 0.025, // small blue dot: visible but won't blob clustered cities together
+    vec: [-o * Math.cos(lngR), Math.sin(latR), o * Math.sin(lngR)],
+  };
+});
+
+// What cobe needs (no `vec`), and an id->marker lookup for the render loop.
+const cobeMarkers = markers.map(({ id, location, size }) => ({
+  id,
+  location,
+  size,
+}));
+const markerById = Object.fromEntries(markers.map((m) => [m.id, m]));
+
+const Globe = () => {
+  const canvasRef = useRef(null);
+  const wrapRef = useRef(null);
+  const markerRefs = useRef({});
+  const cardRef = useRef(null);
+  const cardFlagRef = useRef(null);
+  const cardLabelRef = useRef(null);
+  const pointerInteracting = useRef(null);
+  const pointerInteractionMovement = useRef(0);
+  const hoveredId = useRef(null);
+  const globeHovered = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    const theta = 0.2;
+    let phi = 0;
+    let width = 0;
+    let currentPhi = 0;
+    const doublePi = Math.PI * 2;
+
+    const measureWidth = () =>
+      wrap.clientWidth || canvas.offsetWidth || canvas.clientWidth || 0;
+    width = measureWidth();
+
+    // cobe writes a live-positioned <div> per marker (id-keyed). Cache those so
+    // we can mirror their position onto our own hit areas.
+    let cobeAnchors = {};
+    const getAnchor = (id) => {
+      if (!cobeAnchors[id]) {
+        cobeAnchors[id] = wrap.querySelector(`[style*="--cobe-${id};"]`);
+      }
+      return cobeAnchors[id];
+    };
+
+    let globe;
+    const buildGlobe = () => {
+      if (globe) globe.destroy();
+      cobeAnchors = {}; // anchors are recreated by cobe; drop stale refs
+      globe = createGlobe(canvas, {
+        devicePixelRatio: 2,
+        width: width * 2,
+        height: width * 2,
+        phi: currentPhi,
+        theta,
+        dark: 1,
+        diffuse: 1.1,
+        mapSamples: 16000,
+        mapBrightness: 7,
+        baseColor: [0.34, 0.4, 0.58], // soft slate-blue sphere (not near-black)
+        markerColor: [0, 0.659, 1], // neon blue pins (#00a8ff)
+        glowColor: [0.85, 0.85, 0.87], // soft neutral glow (mono, matches site)
+        markerElevation: 0, // keep markers flat on the surface, not raised
+        markers: cobeMarkers,
+      });
+    };
+    buildGlobe();
+
+    // cobe's update() doesn't resize the canvas buffer, so on a real width
+    // change we rebuild the globe (otherwise it renders shifted/clipped).
+    const onResize = () => {
+      const next = measureWidth();
+      if (next && Math.abs(next - width) > 1) {
+        width = next;
+        buildGlobe();
+      }
+    };
+    const resizeObserver = new ResizeObserver(onResize);
+    resizeObserver.observe(wrap);
+    window.addEventListener('resize', onResize);
+
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+    const LABEL_THRESHOLD = 0.15;
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+
+    const depthOf = (m, f) =>
+      -Math.sin(f) * cosT * m.vec[0] +
+      sinT * m.vec[1] +
+      Math.cos(f) * cosT * m.vec[2];
+
+    // Spotlight: highlight one random marker from those currently facing the
+    // viewer, switching the selection every few seconds.
+    let spotlightId = null;
+    const reselect = () => {
+      const visible = markers.filter(
+        (m) => depthOf(m, currentPhi % doublePi) >= LABEL_THRESHOLD
+      );
+      spotlightId = visible.length
+        ? visible[Math.floor(Math.random() * visible.length)].id
+        : null;
+    };
+
+    let reselectTimer;
+    const scheduleReselect = () => {
+      reselectTimer = setTimeout(
+        () => {
+          reselect();
+          scheduleReselect();
+        },
+        3000 + Math.random() * 1500 // switch every ~3–4.5s
+      );
+    };
+    reselect();
+    scheduleReselect();
+
+    let raf;
+    const render = () => {
+      if (
+        !reduceMotion &&
+        pointerInteracting.current === null &&
+        !globeHovered.current
+      ) {
+        phi += 0.004; // auto-rotate unless hovering the globe, dragging, or reduced motion
+      }
+      // movement is stored in pixels; convert to radians here (drag damping).
+      currentPhi = phi + pointerInteractionMovement.current / 200;
+      const f = currentPhi % doublePi;
+      // width/height are fixed at build time (resize rebuilds), so only phi changes.
+      globe.update({ phi: f });
+
+      // Hover wins over the spotlight; otherwise show the spotlight pick.
+      const activeId = hoveredId.current || spotlightId;
+
+      // Keep our (transparent) hit areas over each front-facing surface marker.
+      for (const m of markers) {
+        const el = markerRefs.current[m.id];
+        const anchor = getAnchor(m.id);
+        if (!el || !anchor) continue;
+        if (depthOf(m, f) >= 0) {
+          el.style.left = anchor.style.left;
+          el.style.top = anchor.style.top;
+          el.style.pointerEvents = 'auto';
+        } else {
+          el.style.pointerEvents = 'none';
+        }
+      }
+
+      // Card floats just above the active pin and follows it; it shows only
+      // while that pin is front-facing.
+      const card = cardRef.current;
+      const activeMarker = activeId ? markerById[activeId] : null;
+      const activeAnchor = activeId ? getAnchor(activeId) : null;
+      const showCallout =
+        activeMarker && activeAnchor && depthOf(activeMarker, f) >= 0;
+
+      if (showCallout) {
+        if (cardLabelRef.current.textContent !== nameOf[activeId]) {
+          cardLabelRef.current.textContent = nameOf[activeId];
+          cardFlagRef.current.textContent = flagOf[activeId];
+        }
+        // Position above the pin, but clamp inside the globe box so the card
+        // never runs off the screen (and flip below if there's no room above).
+        const wrapW = wrap.clientWidth;
+        const wrapH = wrap.clientHeight;
+        const pinX = (parseFloat(activeAnchor.style.left) / 100) * wrapW;
+        const pinY = (parseFloat(activeAnchor.style.top) / 100) * wrapH;
+        const cw = card.offsetWidth;
+        const ch = card.offsetHeight;
+        const pad = 8;
+        const gap = 12;
+        const cx = Math.min(Math.max(pinX, cw / 2 + pad), wrapW - cw / 2 - pad);
+        let top = pinY - gap - ch >= pad ? pinY - gap - ch : pinY + gap;
+        top = Math.min(Math.max(top, pad), wrapH - ch - pad);
+        card.style.left = `${cx}px`;
+        card.style.top = `${top}px`;
+        card.style.transform = 'translateX(-50%)';
+        card.style.opacity = '1';
+      } else {
+        card.style.opacity = '0';
+      }
+
+      raf = requestAnimationFrame(render);
+    };
+    render();
+
+    requestAnimationFrame(() => {
+      canvas.style.opacity = '1';
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(reselectTimer);
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', onResize);
+      if (globe) globe.destroy();
+    };
+  }, []);
+
+  const onPointerDown = (e) => {
+    pointerInteracting.current = e.clientX - pointerInteractionMovement.current;
+    wrapRef.current?.setPointerCapture?.(e.pointerId);
+    if (wrapRef.current) wrapRef.current.style.cursor = 'grabbing';
+  };
+
+  const endInteraction = (e) => {
+    pointerInteracting.current = null;
+    wrapRef.current?.releasePointerCapture?.(e.pointerId);
+    if (wrapRef.current) wrapRef.current.style.cursor = 'grab';
+  };
+
+  const onPointerMove = (e) => {
+    if (pointerInteracting.current === null) return;
+    pointerInteractionMovement.current = e.clientX - pointerInteracting.current;
+  };
+
+  return (
+    <div
+      className="travel-globe-wrap"
+      ref={wrapRef}
+      onPointerEnter={() => {
+        globeHovered.current = true;
+      }}
+      onPointerLeave={() => {
+        globeHovered.current = false;
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endInteraction}
+      onPointerCancel={endInteraction}
+    >
+      <canvas ref={canvasRef} className="travel-globe" />
+
+      <div className="travel-globe-markers">
+        {places.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            className="travel-marker"
+            ref={(el) => {
+              markerRefs.current[p.id] = el;
+            }}
+            onPointerEnter={() => {
+              hoveredId.current = p.id;
+            }}
+            onPointerLeave={() => {
+              hoveredId.current = null;
+            }}
+            aria-label={nameOf[p.id]}
+          />
+        ))}
+      </div>
+
+      <div className="travel-callout" ref={cardRef} aria-hidden="true">
+        <span ref={cardFlagRef} className="travel-callout-flag" />
+        <span ref={cardLabelRef} className="travel-callout-label" />
+      </div>
+    </div>
+  );
+};
+
+export default Globe;

--- a/src/app/travel/TravelGlobe.js
+++ b/src/app/travel/TravelGlobe.js
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// cobe renders to a canvas and touches `window`, so the globe is client-only.
+const Globe = dynamic(() => import('./Globe'), {
+  ssr: false,
+  loading: () => (
+    <div className="travel-globe-wrap travel-globe-loading">Loading globe…</div>
+  ),
+});
+
+export default function TravelGlobe() {
+  return <Globe />;
+}

--- a/src/app/travel/layout.js
+++ b/src/app/travel/layout.js
@@ -1,0 +1,7 @@
+import { metadata } from './metadata';
+
+export { metadata };
+
+export default function TravelLayout({ children }) {
+  return <>{children}</>;
+}

--- a/src/app/travel/metadata.js
+++ b/src/app/travel/metadata.js
@@ -1,0 +1,43 @@
+import { SITE_URL, TWITTER_HANDLE } from '@/lib/constants';
+
+export const metadata = {
+  title: "Pradumna's Travel",
+  description: "Places I've travelled to, shown on an interactive globe.",
+  keywords: ['Pradumna Saraf', 'Travel', 'Places', 'Cities', 'Trips'],
+  openGraph: {
+    title: "Pradumna's Travel",
+    description: "Places I've travelled to, shown on an interactive globe.",
+    url: `${SITE_URL}/travel`,
+    images: [
+      {
+        url: `${SITE_URL}/media/speaking-og.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Pradumna Saraf - Travel',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: "Pradumna's Travel",
+    description: "Places I've travelled to, shown on an interactive globe.",
+    creator: TWITTER_HANDLE,
+    images: [`${SITE_URL}/media/speaking-og.png`],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  alternates: {
+    canonical: `${SITE_URL}/travel`,
+  },
+};

--- a/src/app/travel/page.js
+++ b/src/app/travel/page.js
@@ -1,0 +1,40 @@
+import travelData from './travel.json';
+import TravelGlobe from './TravelGlobe';
+import PageTopbar from '@/components/PageTopbar';
+import './style.css';
+
+const TravelPage = () => {
+  return (
+    <>
+      <PageTopbar ariaLabel="Back to home page" />
+
+      <div className="travel-container">
+        <div className="travel-header">
+          <h1>Travel</h1>
+        </div>
+
+        <div className="travel-globe-section">
+          <TravelGlobe />
+          <p className="travel-caption">
+            Places I&apos;ve travelled. Drag to spin the globe.
+          </p>
+        </div>
+
+        {/* Server-rendered, visually hidden: gives crawlers and screen readers
+            the place list since the globe itself is client-only. */}
+        <ul className="travel-sr-list">
+          {travelData.map((p) => (
+            <li key={p.id}>
+              {p.place}
+              {p.country ? `, ${p.country}` : ''}
+              {p.date ? ` — ${p.date}` : ''}
+              {p.note ? `. ${p.note}` : ''}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default TravelPage;

--- a/src/app/travel/style.css
+++ b/src/app/travel/style.css
@@ -1,0 +1,168 @@
+.travel-container {
+  min-height: calc(100vh - 80px);
+  background: linear-gradient(to bottom, var(--color-surface) 0%, #fcfcfc 100%);
+  padding: 1.25rem 1.25rem 3.5rem;
+  color: var(--color-fg-secondary);
+  /* Globe centers against the whole page; the heading floats at the top. */
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.travel-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  text-align: center;
+}
+
+.travel-header h1 {
+  font-size: 3rem;
+  color: var(--color-fg);
+  margin: 15px 0 0;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+}
+
+.travel-globe-section {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.travel-caption {
+  margin: 0.75rem 0 0;
+  color: var(--color-fg-muted);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+/* Visually hidden, but available to screen readers and crawlers. */
+.travel-sr-list {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* 3D globe (cobe) */
+.travel-globe-wrap {
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
+  aspect-ratio: 1 / 1;
+  position: relative;
+  /* Let vertical page scroll stay smooth on touch; horizontal drag rotates. */
+  touch-action: pan-y;
+}
+
+.travel-globe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+  contain: layout paint size;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  touch-action: pan-y;
+}
+
+.travel-globe-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-fg-muted);
+}
+
+/* Interactive marker overlay positioned over the canvas */
+.travel-globe-markers {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Transparent hit area over each cobe-drawn surface marker (for hover). */
+.travel-marker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  opacity: 0;
+}
+
+/* Card floats just above the active pin and follows it (left/top set in JS) */
+.travel-callout {
+  position: absolute;
+  left: 0;
+  top: 0;
+  /* horizontal centering; vertical position is clamped in JS to stay on-screen */
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-surface);
+  border: 1.5px solid #00a8ff;
+  border-radius: 12px;
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.12),
+    0 2px 6px rgba(0, 0, 0, 0.06);
+  max-width: 240px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 6;
+}
+
+.travel-callout-flag {
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  /* League Spartan rides low in its line box, so the flag looks high; nudge it
+     down a touch to optically center it with the text. */
+  transform: translateY(0.12em);
+}
+
+.travel-callout-label {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-fg);
+  line-height: 1.2;
+}
+
+@media (max-width: 768px) {
+  .travel-container {
+    padding: 0.5rem 0.9rem 2rem;
+  }
+
+  .travel-header h1 {
+    font-size: 2rem;
+    margin-top: 15px;
+  }
+
+  .travel-globe-wrap {
+    max-width: 100%;
+  }
+}

--- a/src/app/travel/travel.json
+++ b/src/app/travel/travel.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "istanbul",
+    "place": "Istanbul",
+    "country": "Turkey",
+    "flag": "🇹🇷",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 41.0082,
+    "lng": 28.9784
+  },
+  {
+    "id": "hong-kong",
+    "place": "Hong Kong",
+    "country": "",
+    "flag": "🇭🇰",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 22.3193,
+    "lng": 114.1694
+  },
+  {
+    "id": "macau",
+    "place": "Macau",
+    "country": "",
+    "flag": "🇲🇴",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 22.1987,
+    "lng": 113.5439
+  },
+  {
+    "id": "mumbai",
+    "place": "Mumbai",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 19.076,
+    "lng": 72.8777
+  },
+  {
+    "id": "hyderabad",
+    "place": "Hyderabad",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 17.385,
+    "lng": 78.4867
+  },
+  {
+    "id": "kolkata",
+    "place": "Kolkata",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 22.5726,
+    "lng": 88.3639
+  },
+  {
+    "id": "agra",
+    "place": "Agra",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 27.1767,
+    "lng": 78.0081
+  },
+  {
+    "id": "new-delhi",
+    "place": "New Delhi",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 28.6139,
+    "lng": 77.209
+  },
+  {
+    "id": "goa",
+    "place": "Goa",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 15.2993,
+    "lng": 74.124
+  },
+  {
+    "id": "fatehpur-sikri",
+    "place": "Fatehpur Sikri",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 27.0937,
+    "lng": 77.6611
+  },
+  {
+    "id": "sikar",
+    "place": "Sikar",
+    "country": "India",
+    "flag": "🇮🇳",
+    "date": "",
+    "note": "",
+    "photo": "",
+    "lat": 27.6094,
+    "lng": 75.1399
+  }
+]


### PR DESCRIPTION
Adds a `/travel` page with an interactive 3D globe (cobe) of places I've visited. Auto-rotates, spotlights one city at a time, drag to spin / hover a pin. Linked from the nav and sitemap; cities are data-driven in `travel.json`.