### PR TITLE
fix(blog): fill empty grid cell above Load more button

### DIFF
--- a/src/components/BlogPostExplorer.js
+++ b/src/components/BlogPostExplorer.js
@@ -90,8 +90,11 @@ export default function BlogPostExplorer({ posts, hideTopicChips = false }) {
     activeTag === 'all' && sortBy === 'latest' && filteredPosts.length > 1;
   const featuredPost = isDefaultView ? filteredPosts[0] : null;
   const gridStartIndex = featuredPost ? 1 : 0;
-  const visiblePosts = filteredPosts.slice(gridStartIndex, visibleCount);
-  const hasMore = visibleCount < filteredPosts.length;
+  const visiblePosts = filteredPosts.slice(
+    gridStartIndex,
+    gridStartIndex + visibleCount
+  );
+  const hasMore = gridStartIndex + visibleCount < filteredPosts.length;
   const hasActiveFilters = activeTag !== 'all';
 
   return (


### PR DESCRIPTION
## Summary

Fixes #86.

On `/blog`, the default view pulls the newest post out as a full-width **featured** card, but the grid slice still ended at `visibleCount` (9). Since the featured post consumed index 0, the 3-column grid only rendered **8 cards**, leaving one empty cell in the last row (the gap in the issue screenshot).

## Change

In `src/components/BlogPostExplorer.js`, offset the slice end by the featured post so the grid always renders a full `visibleCount` of cards:

```js
const visiblePosts = filteredPosts.slice(
  gridStartIndex,
  gridStartIndex + visibleCount
);
const hasMore = gridStartIndex + visibleCount < filteredPosts.length;
```

The grid now shows 9 cards (a full 3x3, no gap). Since both `INITIAL_VISIBLE_POSTS` (9) and `LOAD_MORE_COUNT` (6) are multiples of 3, rows stay filled after each Load more click. Filtered/sorted views (no featured card) are unchanged since `gridStartIndex` is 0 there.

## Testing

- Verified locally on `/blog`: the empty cell above Load more is filled.
- Load more keeps rows full.
- Topic filter / sort changes still render correctly.