### PR TITLE
chore: ignore ESLint v10 major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    # Hold ESLint on v9. eslint-plugin-react caps its ESLint peer dep at
+    # ^9.7 and has not shipped a release supporting v10, so bumping eslint
+    # (or its lockstep @eslint/js) to v10 fails install with ERESOLVE.
+    # Remove these ignores once eslint-plugin-react declares ^10 support.
+    ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Summary

Adds an `ignore` block to the npm section of `.github/dependabot.yml` so Dependabot stops reopening the ESLint v10 major-version PRs.

## Why

`eslint-plugin-react` (latest 7.37.5) caps its ESLint peer dependency at `^9.7` and has not shipped a release supporting ESLint v10. Bumping `eslint` to v10 therefore fails `npm ci` with an `ERESOLVE` peer-dependency conflict (confirmed on PR #93's CI). `@eslint/js` is meant to track the same major as `eslint`, so it is held too. This matches the existing hold documented in `CLAUDE.md`.

Only **semver-major** updates are ignored, so minor/patch bumps for both packages still flow. The block is removed once `eslint-plugin-react` declares `^10` support.

Closes #92, closes #93.