### PR TITLE
fix(photography): smoother mobile loading and scrolling

### DIFF
--- a/src/app/photography/page.js
+++ b/src/app/photography/page.js
@@ -62,6 +62,9 @@ const ImageItem = ({ src, alt, onClick }) => {
         className={`w-full overflow-hidden rounded-lg transition-all duration-300 image-container ${
           isLoading ? 'animate-pulse bg-gray-200' : ''
         }`}
+        // Reserve space before the image loads so lazy-loading doesn't shift
+        // the page and jank the scroll on mobile.
+        style={isLoading ? { aspectRatio: '2 / 3' } : undefined}
       >
         {isVisible && (
           <Image
@@ -77,19 +80,7 @@ const ImageItem = ({ src, alt, onClick }) => {
             }`}
             onClick={onClick}
             onError={() => setHasError(true)}
-            onLoad={() => {
-              setIsLoading(false);
-              // Safari-specific: Force layout recalculation after image loads
-              requestAnimationFrame(() => {
-                const container = document.querySelector(
-                  '.photography-page-container'
-                );
-                if (container) {
-                  // Trigger a reflow to ensure scroll works
-                  void container.offsetHeight;
-                }
-              });
-            }}
+            onLoad={() => setIsLoading(false)}
           />
         )}
       </div>
@@ -277,9 +268,8 @@ const WelcomePopup = ({ isOpen, onClose }) => {
         <div className="popup-content">
           <h2 className="popup-title">Welcome to Photography page!</h2>
           <p className="popup-message">
-            Hover over any image to see it in full color! The images start in
-            grayscale and reveal their vibrant colors when you interact with
-            them.
+            Tap any image to view it full screen. Images start in grayscale and,
+            on desktop, reveal their full color on hover.
           </p>
           <button onClick={onClose} className="popup-ok-button">
             Got it!
@@ -296,7 +286,6 @@ export default function Home() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalImageSrc, setModalImageSrc] = useState('');
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [showWelcomePopup, setShowWelcomePopup] = useState(false);
 
   // Define breakpoint columns (react-masonry-css uses max-width semantics:
@@ -333,45 +322,11 @@ export default function Home() {
   };
 
   useEffect(() => {
-    // Show welcome popup when page loads
+    // Client-only so it doesn't cause an SSR/hydration mismatch. Images load
+    // lazily per-item via IntersectionObserver, so there's no global preload
+    // (mass-preloading every Drive image at once triggered rate-limit 403s).
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setShowWelcomePopup(true);
-
-    // Set a reasonable timeout to automatically clear loading state
-    const timeoutId = setTimeout(() => {
-      setIsLoading(false);
-    }, 8000); // 8 seconds maximum loading time
-
-    // Preload just a few images first for faster initial display
-    const preloadInitialImages = () => {
-      // Only preload first 8 images for quick display
-      const initialImagePromises = images.slice(0, 8).map((img) => {
-        return new Promise((resolve) => {
-          const image = new window.Image();
-          image.src = img.src;
-          image.onload = resolve;
-          image.onerror = resolve;
-        });
-      });
-
-      Promise.all(initialImagePromises)
-        .then(() => {
-          // Set loading to false after initial images load
-          setIsLoading(false);
-
-          // Continue loading the rest in background
-          images.slice(8).forEach((img) => {
-            const image = new window.Image();
-            image.src = img.src;
-          });
-        })
-        .catch(() => {
-          setIsLoading(false);
-        });
-    };
-
-    preloadInitialImages();
-    return () => clearTimeout(timeoutId);
   }, []);
 
   return (
@@ -382,11 +337,6 @@ export default function Home() {
         <h1 className="photography-title">Photography</h1>
 
         <div className="container mx-auto">
-          {isLoading && (
-            <div className="flex justify-center my-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
-            </div>
-          )}
           <Masonry
             breakpointCols={breakpointColumnsObj}
             className="my-masonry-grid"

--- a/src/app/photography/page.js
+++ b/src/app/photography/page.js
@@ -24,34 +24,17 @@ const ImageItem = ({ src, alt, onClick }) => {
         }
       },
       {
-        threshold: 0.01, // Lower threshold for earlier loading
-        rootMargin: '50px', // Start loading images before they're visible
+        threshold: 0.01,
+        // Start fetching ~1.5 screens ahead so images are ready by the time
+        // they scroll into view (paces requests with scroll, not all at once).
+        rootMargin: '1200px 0px',
       }
     );
 
     const currentElement = document.getElementById(`image-${src}`);
     if (currentElement) {
-      // Safari-specific: Use requestAnimationFrame to prevent blocking scroll
-      // This ensures the observer setup doesn't interfere with Safari's scroll handling
-      let timeoutId;
-      const rafId = requestAnimationFrame(() => {
-        timeoutId = setTimeout(() => {
-          const element = document.getElementById(`image-${src}`);
-          if (element) {
-            observer.observe(element);
-          }
-        }, 0);
-      });
-
-      return () => {
-        cancelAnimationFrame(rafId);
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        if (currentElement) {
-          observer.unobserve(currentElement);
-        }
-      };
+      observer.observe(currentElement);
+      return () => observer.unobserve(currentElement);
     }
   }, [src]);
 


### PR DESCRIPTION
## What & why

The photography page was janky on mobile: random scroll jumps, images sometimes not loading, and a spinner rendering behind the welcome popup. Root causes fixed here:

- **Scroll jank** — image containers had no reserved height, so lazy-loading popped them from ~0 to full height and shoved the page around. Each slot now reserves a 2:3 placeholder before its image loads, keeping layout stable.
- **Images sometimes not loading** — the page preloaded *all* ~40 full-size Google Drive originals at once, tripping Drive's rate limiting (403s → images vanished). Removed the mass preload; images now load lazily, paced with scroll (~1.5 screens ahead), so far fewer concurrent Drive requests.
- **Spinner behind the welcome popup** — removed the redundant page-level spinner (each image already has its own skeleton placeholder).
- **Removed a Safari band-aid** that forced a synchronous reflow on every image load (itself a scroll-jank source), now unnecessary with reserved space.
- **Welcome copy** said "Hover over any image" (does nothing on touch) → now "Tap any image to view it full screen."

## Testing

- `npm run lint`, `npm test`, and `npm run build` all pass.
- Please test on a real phone (scroll smoothness + how quickly boxes fill).

## Known follow-up (not in this PR)

The top-of-page images still show a brief skeleton on first load because they're the full 2500px Drive originals served with `unoptimized`. The bigger speed win is enabling Next.js image optimization (remove `unoptimized`) so mobile gets small WebP/AVIF; the complete fix is moving the gallery off Google Drive to a real image CDN.